### PR TITLE
Added git initialization

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,0 +1,4 @@
+from subprocess import call
+call(["git", "init"])
+call(["git", "add", "."])
+call(["git", "commit", "-m", "\"Project created with datakit.\""])


### PR DESCRIPTION
Straightforward: calls in the post-creation hook the following commands
`git init`
`git add .`
`git commit -m "Project created with datakit."`

We are currently pre-generating `.gitignore` files before this step.

This doesn't come close to tackling the more complex task of full git integration, but this will make RStudio turn on its git functionality when opening the `.Rproj` file (it doesn't seem to do so otherwise).